### PR TITLE
Added verbose option for hspace_to_vertex, through options dictionnary

### DIFF
--- a/pycapacity/algorithms.py
+++ b/pycapacity/algorithms.py
@@ -560,7 +560,7 @@ def chebyshev_ball(A,b):
     res = cvxopt.glpk.lp(c=c,  G=G, h=h, options=solvers_opt)
     return np.array(res[1][:-1]).reshape((-1,)), np.array(res[1][-1]).reshape((-1,))
 
-def hspace_to_vertex(H,d):
+def hspace_to_vertex(H,d, verbose = True):
     """
     From half-space representation to the vertex representation
 
@@ -585,12 +585,12 @@ def hspace_to_vertex(H,d):
             hd = HalfspaceIntersection(hd_mat,feasible_point)
             hull = ConvexHull(hd.intersections)
         except:
-            print("H2V: Convex hull issue: using QJ option! ")
+            if(verbose): print("H2V: Convex hull issue: using QJ option! ")
             try:
                 hd = HalfspaceIntersection(hd_mat,feasible_point,qhull_options='QJ')
                 hull = ConvexHull(hd.intersections)
             except:
-                print("H2V: Convex hull issue: using Q0 option! ")
+                if (verbose): print("H2V: Convex hull issue: using Q0 option! ")
                 hd = HalfspaceIntersection(hd_mat,feasible_point,qhull_options='Q0')
                 hull = ConvexHull(hd.intersections)
         return hd.intersections.T, hull.simplices

--- a/pycapacity/human.py
+++ b/pycapacity/human.py
@@ -137,7 +137,10 @@ def joint_torques_polytope(N, F_min, F_max, tol=1e-5, options=None):
             polytope object with the following attributes ``vertices``, half-plane representation ``H``, ``d``, (and ``face_indices`` and ``faces`` if option ``calculate_faces`` is set to ``True``)
     """
     H, d = hyper_plane_shift_method(N, F_min, F_max)
-    vert, faces = hspace_to_vertex(H,d)
+    verbose = True
+    if options is not None and 'verbose' in options.keys() and options['verbose'] is False:
+        verbose = False
+    vert, faces = hspace_to_vertex(H,d, verbose)
 
     # create the polytope object
     poly = Polytope(vertices=vert, H=H, d=d)
@@ -183,7 +186,10 @@ def acceleration_polytope(J, N, M, F_min, F_max, tol=1e-5, options=None):
         poly.face_indices = faces
     else:
         H,d = hyper_plane_shift_method(J.dot(np.linalg.inv(M).dot(N)),F_min,F_max)
-        vert, faces = hspace_to_vertex(H,d) 
+        verbose = True
+        if options is not None and 'verbose' in options.keys() and options['verbose'] is False:
+            verbose = False
+        vert, faces = hspace_to_vertex(H,d, verbose)        
         # construct polytope object
         poly = Polytope(vertices=vert, H=H, d=d)
         poly.face_indices = faces

--- a/pycapacity/objects.py
+++ b/pycapacity/objects.py
@@ -105,7 +105,7 @@ class Polytope:
 
         """
         if self.H is not None and self.d is not None:
-            # finding vertices of the polytope from the half-plane representation
+            # finding vertices of the polytope from the half-plane representation            
             self.vertices, self.face_indices = hspace_to_vertex(self.H,self.d)
         else:
             print("No half-plane representation of the polytope is available")

--- a/pycapacity/robot.py
+++ b/pycapacity/robot.py
@@ -261,7 +261,10 @@ def velocity_polytope(Jacobian, dq_max, dq_min, options = None):
             polytope object with ``vertices``, halfspaces ``H`` and ``d`` (``face_indices`` and ``faces`` if option ``calculate_faces`` is set to True)
     """ 
     H, d = hyper_plane_shift_method(Jacobian,dq_min,dq_max)
-    velocity_vertex, vel_faces = hspace_to_vertex(H,d)
+    verbose = True
+    if options is not None and 'verbose' in options.keys() and options['verbose'] is False:
+        verbose = False
+    velocity_vertex, vel_faces = hspace_to_vertex(H,d, verbose)    
 
     # create polytope
     poly = Polytope(vertices=velocity_vertex, H=H, d=d)
@@ -300,7 +303,11 @@ def acceleration_polytope(J, M, t_max, t_min, t_bias= None, options = None):
         t_max = t_max - t_bias
     
     H, d = hyper_plane_shift_method(B,t_min, t_max)
-    vertex, faces = hspace_to_vertex(H,d)
+    verbose = True
+    if options is not None and 'verbose' in options.keys() and options['verbose'] is False:
+        verbose = False
+    vertex, faces = hspace_to_vertex(H,d, verbose)     
+
 
 
     # create polytope


### PR DESCRIPTION
Sometimes, I have a spam of the except messages of hspace_to_vertex. Do you think we can had an option to desactivate it, through a verbose option? 